### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# My Page
+
+This repository contains a simple personal website.
+
+## Pre-commit hooks
+
+The project includes a [pre-commit](https://pre-commit.com/) configuration to automatically check for common formatting issues. To set up the hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Running `pre-commit install` will configure Git so that these checks run automatically whenever you make a commit.


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with basic hooks
- document how to install pre-commit in `README.md`

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efbc24974832fb3bfa6ff717bb1a5